### PR TITLE
Make the brew installation guide shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ A Rust-powered MCP (Model Context Protocol) server providing AI assistants with 
 
 **macOS / Linux (Homebrew):**
 ```bash
-brew tap postrv/narsil
-brew install narsil-mcp
+brew install postrv/narsil/narsil-mcp
 ```
 
 **Windows (Scoop):**


### PR DESCRIPTION
The `install` command supports directly installing from a github hosted homebrew-tap with this kind of integrated syntax.